### PR TITLE
Use native Array.forEach which is resilient to array changes

### DIFF
--- a/collectionize.js
+++ b/collectionize.js
@@ -26,14 +26,16 @@
   function nativeEach(obj, cb) {
     if (obj && _.isFunction(cb)) {
       if (_.isPlainObject(obj)) {
-        return eachObject(obj, cb);
-      } else if (_.isArray(obj) || _.isString(obj)) {
-        return eachArray(obj, cb);
+        eachObject(obj, cb);
+      } else if (_.isArray(obj)) {
+        obj.forEach(cb);
+      } else if (_.isString(obj)) {
+        eachCharacter(obj, cb)
       }
     }
   }
 
-  function eachArray(obj, cb) {
+  function eachCharacter(obj, cb) {
     var i = 0, max = obj.length;
     for (; i < max; i++) {
       if (cb(obj[i], i, obj) === false) {


### PR DESCRIPTION
While using the update event handler on collectionize in Clubhouse, we ran in to the issue of the event listeners array being modified while iterating it. In our case listeners are being removed due to React hooks responding to entity changes. This resulted in an error because the code is trying to access the name property off an `undefined` listener.
The native `Array.forEach` method does not suffer from this problem and array additions and deletions are allowed during iteration.